### PR TITLE
Docker Compose Volume update

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
     image: postgres:latest
     restart: always
     volumes:
-      - peppermint/db:/data/db
+      - ./peppermint/db:/data/db
     environment: 
       POSTGRES_USER: peppermint
       POSTGRES_PASSWORD: 1234

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -6,7 +6,7 @@ services:
     image: postgres:latest
     restart: always
     volumes:
-      - peppermint/db:/data/db
+      - ./peppermint/db:/data/db
     environment: 
       POSTGRES_USER: peppermint
       POSTGRES_PASSWORD: 1234

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: postgres:latest
     restart: always
     volumes:
-      - peppermint/db:/data/db
+      - ./peppermint/db:/data/db
     environment: 
       POSTGRES_USER: peppermint
       POSTGRES_PASSWORD: 1234


### PR DESCRIPTION
Howdy Peppermint team 😃  

The current docker-compose file is failing on the volume. 

Specific error:
`Named volume "peppermint/db:/data/db:rw" is used in service "postgres" but no declaration was found in the volumes section.`

This error happens when you are trying to create a volume as a subfolder. Easy fix to add './' in front of the volumes and the compose file runs as expected.


