### PR TITLE
Docker compose updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,24 @@
-version: "3.1"
+version: "3.9"
 
 services:
   postgres:
+    profiles:
+      - prod
+      - dev
+      - test
     container_name: postgres
     image: postgres:latest
     restart: always
     volumes:
       - ./peppermint/db:/data/db
-    environment: 
+    environment:
       POSTGRES_USER: peppermint
       POSTGRES_PASSWORD: 1234
       POSTGRES_DB: peppermint
 
-  client:
+  client-prod:
+    profiles:
+      - prod
     container_name: peppermint
     image: pepperlabs/peppermint:latest
     ports:
@@ -22,7 +28,30 @@ services:
       - postgres
     environment:
       PORT: 5001
-      DB_USERNAME: "peppermint"
-      DB_PASSWORD: "1234"
-      DB_HOST: "postgres"
-      BASE_URL: "http://localhost:5001"
+      DB_USERNAME: peppermint
+      DB_PASSWORD: 1234
+      DB_HOST: postgres
+      BASE_URL: http://localhost:5001
+
+  client-dev:
+    profiles:
+      - dev
+      - test
+    container_name: peppermint_dev
+    image: node:16-alpine
+    working_dir: /src/app
+    volumes:
+      - .:/src/app
+    ports:
+      - 5001:5001
+    restart: on-failure
+    depends_on:
+      - postgres
+    command: yarn run:dev
+
+    environment:
+      PORT: 5001
+      DB_USERNAME: peppermint
+      DB_PASSWORD: 1234
+      DB_HOST: postgres
+      BASE_URL: http://localhost:5001

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "private": true,
   "scripts": {
-    "dev": "next dev ",
+    "dev": "next dev",
+    "run:dev": "yarn migrate && yarn generate && yarn seed && yarn dev",
     "build": "next build",
     "start": "next start",
     "seed": "prisma db seed",


### PR DESCRIPTION
Updates Docker-Compose to use a single compose with profiles for Dev/Test/Prod. Dev and Test profiles will use a hot-reloading container by mounting the local directories directly in the container, and running a generic nodejs container to run them. Prod will use the peppermint:latest container as before. Also updated package.json to include a `run:dev` script for the compose. This will be useful later to do Testing using cypress and start-server-and-test, which I'm also working on.