### PR TITLE
Always restart containers and add healthcheck

### DIFF
--- a/.env
+++ b/.env
@@ -5,12 +5,12 @@
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
 NODE_ENV=development
-PORT=3000
+PORT=5001
 SECRET="lXVsKy1aOGTyAgrqdU5JBa8J5Iu+sRdJ1e9LEH++dtM="
 DB_USERNAME=postgres
 DB_PASSWORD=1234
 DB_HOST=localhost
 DATABASE_URL="postgresql://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:5432/peppermint?schema=public"
-BASE_URL=http://localhost:3000
+BASE_URL=http://localhost:5001
 NEXTAUTH_URL=${BASE_URL}
 NEXT_PUBLIC_VERSION="0.2.3"

--- a/components/CreateTicketModal/index.js
+++ b/components/CreateTicketModal/index.js
@@ -70,7 +70,7 @@ export default function CreateTicketModal() {
     await fetch("/api/v1/ticket/create", {
       method: "POST",
       headers: {
-        "content-type": "application/sjon",
+        "content-type": "application/json",
       },
       body: JSON.stringify({
         name,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,7 +22,7 @@ services:
     depends_on:
       - postgres
     healthcheck:
-      test: ["CMD", "wget", "--spider", "$BASE_URL"]
+      test: ["CMD", "sh", "-c", "wget --spider $$BASE_URL"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,7 +8,7 @@ services:
     restart: always
     volumes:
       - ./peppermint/db:/data/db
-    environment: 
+    environment:
       POSTGRES_USER: peppermint
       POSTGRES_PASSWORD: 1234
       POSTGRES_DB: peppermint
@@ -18,9 +18,14 @@ services:
     image: pepperlabs/peppermint:dev
     ports:
       - 5001:5001
-    restart: on-failure
+    restart: always
     depends_on:
       - postgres
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "$BASE_URL"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
     environment:
       PORT: 5001 ## This is the port of the internal application there is no need to change this
       DB_USERNAME: "peppermint"

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -7,21 +7,26 @@ services:
     restart: always
     volumes:
       - ./peppermint/db:/data/db
-    environment: 
+    environment:
       POSTGRES_USER: peppermint
       POSTGRES_PASSWORD: 1234
       POSTGRES_DB: peppermint
 
   peppermint:
     container_name: peppermint
-    build: . 
+    build: .
     ports:
       - 5001:5001
-    restart: on-failure
+    restart: always
     depends_on:
       - postgres
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "$BASE_URL"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
     environment:
-      PORT: 5001 ## This should follow your ports above, and the port in your base url 
+      PORT: 5001 ## This should follow your ports above, and the port in your base url
       DB_USERNAME: "peppermint"
       DB_PASSWORD: "1234"
       DB_HOST: "postgres"

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -21,7 +21,7 @@ services:
     depends_on:
       - postgres
     healthcheck:
-      test: ["CMD", "wget", "--spider", "$BASE_URL"]
+      test: ["CMD", "sh", "-c", "wget --spider $$BASE_URL"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     restart: always
     volumes:
       - ./peppermint/db:/data/db
-    environment: 
+    environment:
       POSTGRES_USER: peppermint
       POSTGRES_PASSWORD: 1234
       POSTGRES_DB: peppermint
@@ -17,9 +17,14 @@ services:
     image: pepperlabs/peppermint:latest
     ports:
       - 5001:5001
-    restart: on-failure
+    restart: always
     depends_on:
       - postgres
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "$BASE_URL"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
     environment:
       PORT: 5001
       DB_USERNAME: "peppermint"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     depends_on:
       - postgres
     healthcheck:
-      test: ["CMD", "wget", "--spider", "$BASE_URL"]
+      test: ["CMD", "sh", "-c", "wget --spider $$BASE_URL"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/pages/api/v1/admin/user/create.js
+++ b/pages/api/v1/admin/user/create.js
@@ -9,7 +9,7 @@ export default async function createUser(req, res) {
 
   try {
     if (session.user.isAdmin) {
-      const hash = bcrypt.hash(password, 10);
+      const hash = await bcrypt.hash(password, 10);
 
       await prisma.user.create({
         data: {


### PR DESCRIPTION
This PR does the following:

- Changed the port number in .env to match the dockerfile. 
  - `docker-compose up` caused the environment variables inside the container to be using the wrong port.
- Changed the restart policy to "always". 
  - I believe this is preferred when you have something long-running like a webserver since there can sometimes be edge cases where the container doesn't return a non-zero exit code on error. `docker-compose down` and other intentional actions still stop the container like normal. Also, kompose expects a restart policy of "always", otherwise it will create a bare Pod instead of a Deployment: https://kompose.io/
- Added a healthcheck
  - Healthchecks can help if the application hits a deadlock or some other issue that requires a restart. Also helps `kompose` generate Kubernetes healthchecks.
- Fixed a typo in the content-type of the request when creating tickets