### PR TITLE
Fix duplicated youtube channel

### DIFF
--- a/apps/site/pages/index.tsx
+++ b/apps/site/pages/index.tsx
@@ -99,9 +99,9 @@ const posts = [
     date: "30th Mar 2023 ",
     datetime: "2023-03-30",
     author: {
-      name: "DB Tech",
+      name: "Network Chuck",
       role: "Content Creator / Youtuber",
-      href: "https://www.youtube.com/@DBTechYT",
+      href: "https://www.youtube.com/@NetworkChuck",
       imageUrl:
         "https://yt3.googleusercontent.com/ytc/AL5GRJW5XsaEbRr2gFUPOzr8i0iVyS7vihYNp0sAKXsrBA=s176-c-k-c0x00ffffff-no-rj",
     },


### PR DESCRIPTION
On the website you currently have DB tech repeated twice. The second video is from Network Chuck, logo is correct, but title and url to youtube account were a repeat of DB tech.