### PR TITLE
Add placeholder to ticket editor

### DIFF
--- a/apps/client/components/CreateTicketModal/index.js
+++ b/apps/client/components/CreateTicketModal/index.js
@@ -7,6 +7,7 @@ import { useEditor } from "@tiptap/react";
 import Highlight from "@tiptap/extension-highlight";
 import StarterKit from "@tiptap/starter-kit";
 import Underline from "@tiptap/extension-underline";
+import Placeholder from '@tiptap/extension-placeholder';
 // import TextAlign from '@tiptap/extension-text-align';
 import Superscript from "@tiptap/extension-superscript";
 import SubScript from "@tiptap/extension-subscript";
@@ -24,7 +25,7 @@ export default function CreateTicketModal() {
   const [company, setCompany] = useState();
   const [engineer, setEngineer] = useState();
   const [email, setEmail] = useState("");
-  const [issue, setIssue] = useState(t("ticket_extra_details"));
+  const [issue, setIssue] = useState("");
   const [title, setTitle] = useState("");
   const [priority, setPriority] = useState("Normal");
   const [options, setOptions] = useState([]);
@@ -40,6 +41,7 @@ export default function CreateTicketModal() {
       Superscript,
       SubScript,
       Highlight,
+      Placeholder.configure({ placeholder: t("ticket_extra_details") })
       // TextAlign.configure({ types: ['heading', 'paragraph'] }),
     ],
     content: issue,

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -21,6 +21,7 @@
     "@tailwindcss/forms": "^0.4.0",
     "@tiptap/extension-highlight": "^2.0.3",
     "@tiptap/extension-link": "^2.0.3",
+    "@tiptap/extension-placeholder": "^2.1.13",
     "@tiptap/extension-subscript": "^2.0.3",
     "@tiptap/extension-superscript": "^2.0.3",
     "@tiptap/extension-text-align": "^2.0.3",

--- a/apps/client/pages/new.tsx
+++ b/apps/client/pages/new.tsx
@@ -1,4 +1,5 @@
 import { Link, RichTextEditor } from "@mantine/tiptap";
+import Placeholder from '@tiptap/extension-placeholder';
 import Highlight from "@tiptap/extension-highlight";
 import Underline from "@tiptap/extension-underline";
 import { useEditor } from "@tiptap/react";
@@ -39,7 +40,7 @@ export default function CreateTicket() {
   const [company, setCompany] = useState<any>();
   const [engineer, setEngineer] = useState<any>();
   const [email, setEmail] = useState("");
-  const [issue, setIssue] = useState<any>(t("ticket_extra_details"));
+  const [issue, setIssue] = useState<any>("");
   const [title, setTitle] = useState("");
   const [priority, setPriority] = useState("Normal");
   const [options, setOptions] = useState<any>();
@@ -54,6 +55,7 @@ export default function CreateTicket() {
       Superscript,
       SubScript,
       Highlight,
+      Placeholder.configure({ placeholder: t("ticket_extra_details") })
       // TextAlign.configure({ types: ['heading', 'paragraph'] }),
     ],
     content: issue,
@@ -378,6 +380,7 @@ export default function CreateTicket() {
         <div className="w-full xl:w-2/3 order-2 xl:order-2">
           <RichTextEditor
             editor={editor}
+            placeholder={t("ticket_extra_details")}
             className="dark:bg-gray-900 dark:text-white rounded-none border-none"
           >
             <RichTextEditor.Toolbar className="rounded-none dark:bg-[#0A090C]">


### PR DESCRIPTION
Currently, the ticket editor does set the ticket's text to what the editor's placeholder should be. That results in having to remove that hint text on every ticket creation before typing text.

This PR adds the placeholder extension and adds the hint text as a placeholder background text instead.

Note: This adds the extension in the most current version. Maybe it would be advisable to upgrade the rest of the mantine components to the same version when merging.

<img width="704" alt="image" src="https://github.com/Peppermint-Lab/peppermint/assets/6633403/666154bf-8629-4bdf-968b-c7423faabc05">
