### PR TITLE
Fixed Unable to delete webhooks

### DIFF
--- a/apps/client/pages/admin/webhooks.js
+++ b/apps/client/pages/admin/webhooks.js
@@ -53,7 +53,6 @@ export default function Notifications() {
     await fetch(`/api/v1/admin/webhook/${id}/delete`, {
       method: "DELETE",
       headers: {
-        "Content-Type": "application/json",
         Authorization: `Bearer ${getCookie("session")}`,
       },
     })


### PR DESCRIPTION
Fixed Unable to delete webhooks by removing the "Content-Type": "application/json" header