### PR TITLE
Replace hardcoded mail 'from' property

### DIFF
--- a/apps/api/src/lib/nodemailer/auth/forgot-password.ts
+++ b/apps/api/src/lib/nodemailer/auth/forgot-password.ts
@@ -9,6 +9,7 @@ export async function forgotPassword(
 ) {
   try {
     let mail;
+    let replyto;
 
     const emails = await prisma.email.findMany();
 
@@ -27,6 +28,7 @@ export async function forgotPassword(
         });
       } else {
         const email = emails[0];
+        replyto = email.reply;
         mail = nodeMailer.createTransport({
           // @ts-ignore
           host: email.host,
@@ -42,7 +44,7 @@ export async function forgotPassword(
       console.log("Sending email to: ", email);
 
       let info = await mail.sendMail({
-        from: "noreply@peppermint.sh", // sender address
+        from: replyto, // sender address
         to: email, // list of receivers
         subject: `Password Reset Request`, // Subject line
         text: `Password Reset Code: ${code}, follow this link to reset your password ${resetlink}`, // plain text body

--- a/apps/api/src/lib/nodemailer/ticket/assigned.ts
+++ b/apps/api/src/lib/nodemailer/ticket/assigned.ts
@@ -4,6 +4,7 @@ import { prisma } from "../../../prisma";
 export async function sendAssignedEmail(email: any) {
   try {
     let mail;
+    let replyto;
 
     const emails = await prisma.email.findMany();
 
@@ -20,6 +21,7 @@ export async function sendAssignedEmail(email: any) {
         });
       } else {
         const email = emails[0];
+        replyto = email.reply;
         mail = nodeMailer.createTransport({
           // @ts-ignore
           host: email.host,

--- a/apps/api/src/lib/nodemailer/ticket/comment.ts
+++ b/apps/api/src/lib/nodemailer/ticket/comment.ts
@@ -8,6 +8,7 @@ export async function sendComment(
 ) {
   try {
     let mail;
+    let replyto;
 
     console.log("Sending email to: ", email);
 
@@ -26,6 +27,7 @@ export async function sendComment(
         });
       } else {
         const email = emails[0];
+        replyto = email.reply;
         mail = nodeMailer.createTransport({
           // @ts-ignore
           host: email.host,
@@ -40,7 +42,7 @@ export async function sendComment(
 
       await mail
         .sendMail({
-          from: '"No reply 👻" noreply@peppermint.sh', // sender address
+          from: '"No reply 👻" ' + replyto, // sender address
           to: email,
           subject: `New comment on a ticket`, // Subject line
           text: `Hello there, Ticket: ${title}, has had an update with a comment of ${comment}`, // plain text body

--- a/apps/api/src/lib/nodemailer/ticket/create.ts
+++ b/apps/api/src/lib/nodemailer/ticket/create.ts
@@ -4,6 +4,7 @@ import { prisma } from "../../../prisma";
 export async function sendTicketCreate(ticket: any) {
   try {
     let mail;
+    let replyto;
 
     const emails = await prisma.email.findMany();
 
@@ -20,6 +21,7 @@ export async function sendTicketCreate(ticket: any) {
         });
       } else {
         const email = emails[0];
+        replyto = email.reply;
         mail = nodeMailer.createTransport({
           // @ts-ignore
           host: email.host,
@@ -34,7 +36,7 @@ export async function sendTicketCreate(ticket: any) {
 
       await mail
         .sendMail({
-          from: '"No reply 👻" noreply@peppermint.sh', // sender address
+          from: '"No reply 👻" ' + replyto, // sender address
           to: ticket.email,
           subject: `Ticket ${ticket.id} has just been created & logged`, // Subject line
           text: `Hello there, Ticket ${ticket.id}, which you reported on ${ticket.createdAt}, has now been created and logged`, // plain text body

--- a/apps/api/src/lib/nodemailer/ticket/status.ts
+++ b/apps/api/src/lib/nodemailer/ticket/status.ts
@@ -3,6 +3,7 @@ import { prisma } from "../../../prisma";
 
 export async function sendTicketStatus(ticket: any) {
   let mail;
+  let replyto;
 
   const emails = await prisma.email.findMany();
 
@@ -19,6 +20,7 @@ export async function sendTicketStatus(ticket: any) {
       });
     } else {
       const email = emails[0];
+      replyto = email.reply;
       mail = nodeMailer.createTransport({
         //@ts-ignore
         host: email.host,
@@ -33,7 +35,7 @@ export async function sendTicketStatus(ticket: any) {
 
     await mail
       .sendMail({
-        from: "noreply@peppermint.sh", // sender address
+        from: replyto, // sender address
         to: ticket.email,
         subject: `Ticket ${ticket.id} status is now ${
           ticket.isComplete ? "COMPLETED" : "OUTSTANDING"


### PR DESCRIPTION
This commit fixes the following error:
 - Message failed: 553 Relaying disallowed as noreply@peppermint.sh

@rubenhoenle already did a pr (#221)  for this issue but it was for the main branch.
Thats why i created this commit on the next branch so a merge would be simpler.