### PR TITLE
Updated SEO config, and Version on docs

### DIFF
--- a/apps/docs/seo.config.js
+++ b/apps/docs/seo.config.js
@@ -3,10 +3,10 @@ const seoConfig = {
   title: {
     template: "Peppermint",
     default:
-      "Peppermint - An open source zendesk alternative with a focus on simplicity and speed",
+      "Peppermint - Revolutionizing Customer Support for Rapid Resolutions. Your Premier Zendesk Alternative.",
   },
   description:
-    "Peppermint is an open source zendesk alternative with a focus on simplicity and speed",
+    "Experience Peppermint's revolutionary approach to customer support, ensuring swift resolutions. Discover your ultimate alternative to Zendesk.",
   themeColor: "#F6E458",
   openGraph: {
     images: "/og-image.png",

--- a/apps/docs/theme.config.jsx
+++ b/apps/docs/theme.config.jsx
@@ -30,8 +30,8 @@ const config = {
    banner: {
     key: 'release',
     text: (
-      <a href="https://github.com/Peppermint-Lab/peppermint" target="_blank">
-        🎉 Peppermint 0.4 is released. Read more →
+      <a href="https://github.com/Peppermint-Lab/peppermint/releases" target="_blank">
+        🎉 Peppermint 0.4.5 is here! Check it out now! 🚀
       </a>
     )
   },

--- a/apps/site/pages/index.tsx
+++ b/apps/site/pages/index.tsx
@@ -464,7 +464,7 @@ export default function Home() {
         <div className="mx-auto max-w-7xl px-6 pb-8 pt-16 sm:pt-24 lg:px-8 lg:pt-32">
           <div className="mt-16 border-t border-gray-900/10 pt-8 sm:mt-20 lg:mt-24">
             <p className="text-xs leading-5 text-gray-500">
-              &copy; 2023 Peppermint Labs Ltd. All rights reserved.
+              &copy; 2024 Peppermint Labs Ltd. All rights reserved.
             </p>
           </div>
         </div>


### PR DESCRIPTION
I updated the SEO to include more SEO-friendly wording for higher ranking. I have also updated the version # on the docs page to match the front page. Additionally, clicking on the notification at the top of the docs page now takes you to the releases page rather than the GitHub itself. Sorry if you got spammed, I was doing some testing in the wrong branch, but I fixed it now. 