### PR TITLE
Fix Unassigned ticket call to correct API endpoint

### DIFF
--- a/apps/client/pages/index.tsx
+++ b/apps/client/pages/index.tsx
@@ -59,7 +59,7 @@ export default function Home() {
   }
 
   async function getUnassginedTickets() {
-    await fetch(`/api/v1/data/tickets/open`, {
+    await fetch(`/api/v1/data/tickets/unassigned`, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${token}`,


### PR DESCRIPTION
Fixed unassigned ticket call to correct API endpoint as per https://www.reddit.com/r/selfhosted/comments/1bo4ert/comment/kwneu6j/

This PR assumes the api endpoint "/api/v1/data/tickets/unassigned" is working properly (as per code shown in https://github.com/Peppermint-Lab/peppermint/blob/146263fa22ce722a2717e49923a06f794c689c9b/apps/api/src/controllers/data.ts#L61 it should be working)