### PR TITLE
Typo in peppermint.json - de

### DIFF
--- a/apps/client/locales/de/peppermint.json
+++ b/apps/client/locales/de/peppermint.json
@@ -52,7 +52,7 @@
   "notebooks": "Notizbücher",
   "notebooks_description": "Dies ist ein persönliches Notizbuch. Hier können Sie Notizen, Links, Code-Snippets usw. speichern.",
   "create_notebook": "Notizbuch erstellen",
-  "open": "Öffnen",
+  "open": "Offen",
   "assigned_to_me": "Mir Zugewiesen",
   "unassigned": "Nicht Zugewiesen",
   "closed": "Geschlossen",


### PR DESCRIPTION
Just a small change because "open" here means "offen" as a status and not "öffnen" as something someone does, like opening a Window.