### PR TITLE
Add default login to docker page

### DIFF
--- a/apps/docs/pages/docker.mdx
+++ b/apps/docs/pages/docker.mdx
@@ -56,3 +56,10 @@ docker-compose up -d
 ```
 
 Then you can access the application at http://your-server-ip:3000
+
+The default login credentials for the admin account are:
+
+```
+admin@admin.com
+1234
+```


### PR DESCRIPTION
Adds the Peppermint default login to the Docker Docs page, to make it so users don't have to run around trying to find it. I encountered this issue when installing it myself. I didn't go to GitHub, I went straight from the website to the docs.