### PR TITLE
Remove deprecated 'portal_locale' in seed

### DIFF
--- a/apps/api/src/prisma/seed.js
+++ b/apps/api/src/prisma/seed.js
@@ -39,7 +39,6 @@ async function main() {
       data: {
         gh_version: "0.4.3",
         client_version: "0.4.3",
-        portal_locale: "en",
         encryption_key: encryptionKey,
       },
     });


### PR DESCRIPTION
Remove deprecated 'portal_locale' in seed as the column no longer exists in the database after the `clean` migration. Currently, seeing data is broken on the latest commit(s).