### PR TITLE
Add DNS settings to docker compose - Crow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,9 @@ services:
       - 1000:3000
       - 1001:5003
     restart: always
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
     depends_on:
       - peppermint_postgres
     environment:


### PR DESCRIPTION
Crow (on Discord) discovered an issue that prevented the SMTP setup from working until dns entries were added to the docker-compose.yml file.