### PR TITLE
Add DNS comment to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,10 @@ services:
     ports:
       - 1000:3000
       - 1001:5003
+# If running via Docker on a hypervisor, enable DNS.
+#    dns:
+#      - 1.1.1.1
+#      - 8.8.8.8
     restart: always
     depends_on:
       - peppermint_postgres


### PR DESCRIPTION
I run a hypervisor on Freebsd which runs Ubuntu with Peppermint in a Docker conatiner.  This setup does not have DNS by default.  To use SMTP or similar calls, DNS is required.