### PR TITLE
Moving Nginx config to be treated by Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,5 +31,16 @@ services:
       DB_HOST: "peppermint_postgres"
       SECRET: 'peppermint4life'
 
+  peppermint_nginx:
+    container_name: peppermint_nginx
+    image: nginx:latest
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - peppermint
+
 volumes:
  pgdata_live:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,45 @@
+server {
+    listen 80;
+    listen [::]:80;
+
+    # This catches requests to the IP address
+    server_name _;   # Underscore is a catch-all
+
+    return 301 $scheme://helpdesk.omegadigital.us$request_uri;
+}
+
+server {
+    server_name helpdesk.omegadigital.us;
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/helpdesk.omegadigital.us/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/helpdesk.omegadigital.us/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+}
+server {
+    if ($host = helpdesk.omegadigital.us) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+
+    server_name helpdesk.omegadigital.us;
+    listen 80;
+    return 404; # managed by Certbot
+
+
+}


### PR DESCRIPTION
## Add Nginx Reverse Proxy to Docker Setup

### Summary

This PR introduces an Nginx service to the Docker setup, enabling reverse proxy functionality for the Peppermint application. The Nginx configuration is designed to route traffic to both the client and API services, enhancing the application's accessibility and security.

### Changes

- **docker-compose.yml**:
  - Added a new service `peppermint_nginx` using the `nginx:latest` image.
  - Exposed ports 80 and 443 for HTTP and HTTPS traffic.
  - Mounted a custom Nginx configuration file to `/etc/nginx/nginx.conf`.

- **nginx.conf**:
  - Configured Nginx to act as a reverse proxy for the client and API services.
  - Set up server blocks to handle requests on port 80 and forward them to the respective services.