### PR TITLE
Update profile conflict language

### DIFF
--- a/apps/client/pages/profile.tsx
+++ b/apps/client/pages/profile.tsx
@@ -108,7 +108,6 @@ export default function UserProfile() {
                     <option value="es">Spanish</option>
                     <option value="no">Norwegian</option>
                     <option value="fr">French</option>
-                    <option value="pt">Tagalong</option>
                     <option value="da">Danish</option>
                     <option value="pt">Portuguese</option>
                     <option value="it">Italiano</option>


### PR DESCRIPTION
When selecting the Portuguese language it created a conflict with the Tagalong language which had a value of pt , as we still don't have a language in Filipino, delete this language and the conflict stopped.