### PR TITLE
feat(i18n): update the french translation file

### DIFF
--- a/apps/client/locales/fr/peppermint.json
+++ b/apps/client/locales/fr/peppermint.json
@@ -82,5 +82,11 @@
   "select_a_client": "Sélectionner un Client",
   "select_an_engineer": "Sélectionner un Ingénieur",
   "ticket_create": "Créer un Ticket",
-  "internallycommented_at": "Commenté en Interne à"
+  "internallycommented_at": "Commenté en Interne à",
+  "reopen_issue": "Rouvrir une Issue",
+  "needs_support": "Nécessite le Support",
+  "in_progress": "En Cours",
+  "in_review": "En Review",
+  "done": "Fait",
+  "select_new_user": "Sélectionner un nouvel utilisateur"
 }


### PR DESCRIPTION
# Description

I add the missing translation of the i18n translation for the French.

# Changes

Add translation for `reopen_issue`, `needs_support`, `in_progress`, `in_review`, `done`, `select_new_user`