### PR TITLE
Refactor: Remove feedback button, version display, and account links

### DIFF
--- a/apps/client/components/AccountDropdown/index.tsx
+++ b/apps/client/components/AccountDropdown/index.tsx
@@ -121,22 +121,6 @@ export function AccountDropdown() {
           </DropdownMenuItem>
         </DropdownMenuGroup> */}
         <DropdownMenuSeparator />
-        <DropdownMenuItem
-          className="hover:cursor-pointer"
-          onClick={() =>
-            router.push("https://github.com/Peppermint-Lab/peppermint")
-          }
-        >
-          <Github className="mr-2 h-4 w-4" />
-          <span>GitHub</span>
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          className="hover:cursor-pointer"
-          onClick={() => router.push("https://discord.gg/XDxnWxCqnc")}
-        >
-          <LifeBuoy className="mr-2 h-4 w-4" />
-          <span>Support</span>
-        </DropdownMenuItem>
         <DropdownMenuItem disabled>
           <Cloud className="mr-2 h-4 w-4" />
           <span>API</span>

--- a/apps/client/layouts/newLayout.tsx
+++ b/apps/client/layouts/newLayout.tsx
@@ -471,13 +471,6 @@ export default function NewLayout({ children }: any) {
 
             <div className="flex flex-1 gap-x-4 self-stretch lg:gap-x-6 items-center">
               <div className="sm:flex hidden w-full justify-start items-center space-x-6">
-                {user.isAdmin && (
-                  <Link href="https://github.com/Peppermint-Lab/peppermint/releases">
-                    <span className="inline-flex items-center rounded-md bg-green-700/10 px-3 py-2 text-xs font-medium text-green-600 ring-1 ring-inset ring-green-500/20">
-                      Version {process.env.NEXT_PUBLIC_CLIENT_VERSION}
-                    </span>
-                  </Link>
-                )}
               </div>
 
               <div className="flex w-full justify-end items-center gap-x-2 lg:gap-x-2 ">
@@ -500,21 +493,6 @@ export default function NewLayout({ children }: any) {
                     )}
                   </Link>
                 </Button>
-
-                {user.isAdmin && (
-                  <Link
-                    href="https://github.com/Peppermint-Lab/peppermint/discussions"
-                    target="_blank"
-                    className="hover:cursor-pointer"
-                  >
-                    <Button
-                      variant="outline"
-                      className="text-foreground hover:cursor-pointer whitespace-nowrap"
-                    >
-                      Send Feedback
-                    </Button>
-                  </Link>
-                )}
 
                 {/* Profile dropdown */}
                 <AccountDropdown />


### PR DESCRIPTION
Removes the following UI elements:
- "Send Feedback" button from the main header.
- Version number display from the main header.
- "GitHub" link from the "My Account" dropdown.
- "Support" link from the "My Account" dropdown.

These changes address the issue of decluttering the interface by removing unnecessary or redundant elements as requested.