### PR TITLE
Change volume mount point from /var/lib/postgresql/data to /var/lib/postgresql

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,7 @@ services:
     image: postgres:latest
     restart: always
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
     environment:
       POSTGRES_USER: peppermint
       POSTGRES_PASSWORD: 1234

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -6,7 +6,7 @@ services:
     image: postgres:latest
     restart: always
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
     environment:
       POSTGRES_USER: peppermint
       POSTGRES_PASSWORD: 1234

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: postgres:latest
     restart: always
     volumes:
-      - pgdata_live:/var/lib/postgresql/data
+      - pgdata_live:/var/lib/postgresql
     environment:
       POSTGRES_USER: peppermint
       POSTGRES_PASSWORD: 12345


### PR DESCRIPTION
In postgresql 18, the volume has been changed from `/var/lib/postgresql/data` to `/var/lib/postgresql`. See [here](https://github.com/docker-library/postgres/commit/b9a533c87bdd767c228bf4c7490f9a6437a7d9f3) for the relevant commit.

Version 18 was released September 25, so the `:latest` tag in peppermint's docker-compose.yml now pulls this. Without this change an anonymous volume is created at `/var/lib/postgresql` every time the container starts. This fixes the mount point for all three docker compose files to be consistent with version 18.