### PR TITLE
Fix nightly.yml and release.yml to not fail.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,7 @@ jobs:
 
       # Install QEMU-based emulator
       - name: Install QEMU
-        run: apt-get update && apt-get install -y qemu-user-static
+        run: sudo apt update && sudo apt install -y qemu-user-static
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
       # Install QEMU-based emulator
       - name: Install QEMU
-        run: apt-get update && apt-get install -y qemu-user-static
+        run: sudo apt update && sudo apt install -y qemu-user-static
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Get current time
         uses: 1466587594/get-current-time@v2


### PR DESCRIPTION
Very simple fix, add sudo to the apt commands. Also set release.yml to use ubuntu-latest instead of self-hosted, which was causing it to never run. This may need to change, but it seems that none of the previous runs succeeded. I see no downside to changing this, but it could be a problem to someone else. 